### PR TITLE
Fix planner scripts to use centralized get_resource utility

### DIFF
--- a/skills/scripts/skills/planner/planner.py
+++ b/skills/scripts/skills/planner/planner.py
@@ -35,7 +35,7 @@ from skills.lib.workflow.formatters import (
     format_qr_banner,
 )
 from skills.lib.workflow.cli import add_qr_args
-from skills.planner.shared.resources import get_mode_script_path
+from skills.planner.shared.resources import get_mode_script_path, get_resource
 
 
 # Module path for -m invocation
@@ -154,8 +154,7 @@ If any step was skipped: STOP. Go back and complete it.
 
 def get_plan_format() -> str:
     """Read the plan format template from resources."""
-    format_path = Path(__file__).parent.parent / "resources" / "plan-format.md"
-    return format_path.read_text()
+    return get_resource("plan-format.md")
 
 
 # Unified step definitions (1-13)


### PR DESCRIPTION
### **User description**
## Summary
Fixed `NameError: name 'Path' is not defined` in planner scripts by using the centralized `get_resource()` utility instead of direct `Path` usage.

## Changes
- **planner.py**: Updated `get_plan_format()` to use `get_resource("plan-format.md")` instead of direct Path construction

## Root Cause
During the refactor in commit 181090d, resource-loading utilities were centralized in `skills.planner.shared.resources` with the `get_resource()` function. However, `get_plan_format()` was written to duplicate this logic using direct `Path` usage without importing `pathlib`, causing runtime failures.

## Testing
- ✓ `python3 -m skills.planner.planner --step 5 --total-steps 13` - succeeds
- ✓ Verified no other files use `Path` without proper imports


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed `NameError: name 'Path' is not defined` in planner scripts

- Replaced direct `Path` usage with centralized `get_resource()` utility

- Simplified `get_plan_format()` by removing manual path manipulation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Direct Path usage<br/>without import"] -->|"Replace with"| B["get_resource()<br/>utility function"]
  B -->|"Fixes"| C["NameError in<br/>planner.py"]
  D["planner.py<br/>get_plan_format"] -->|"Updated"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>planner.py</strong><dd><code>Use centralized get_resource utility instead of Path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/scripts/skills/planner/planner.py

<ul><li>Added <code>get_resource</code> import from <code>skills.planner.shared.resources</code><br> <li> Replaced direct <code>Path</code> construction with <code>get_resource("plan-format.md")</code> <br>call<br> <li> Simplified <code>get_plan_format()</code> by removing manual path manipulation and <br>file operations</ul>


</details>


  </td>
  <td><a href="https://github.com/solatis/claude-config/pull/13/files#diff-36d04e7dddf6276d5d87a768339fe5b372ec826fd0675eed2c8aa13503931e36">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

