### PR TITLE
fix: 3 bugs in incoherence detector script

### DIFF
--- a/skills/scripts/skills/incoherence/incoherence.py
+++ b/skills/scripts/skills/incoherence/incoherence.py
@@ -159,7 +159,7 @@ SELECTION RULES:
 
 
 
-def format_incoherence_output(step, phase, agent_type, guidance):
+def format_incoherence_output(step, phase, agent_type, guidance, thoughts=""):
     """Format output using AST builder API."""
     parts = []
     title = f"INCOHERENCE [{phase}] [{agent_type}]"
@@ -169,6 +169,10 @@ def format_incoherence_output(step, phase, agent_type, guidance):
         step=str(step),
     )))
     parts.append("")
+
+    if thoughts:
+        parts.append(f"<context>\n{thoughts}\n</context>")
+        parts.append("")
 
     if step == 1:
         parts.append("""<xml_format_mandate>
@@ -183,10 +187,15 @@ CRITICAL: All script outputs use XML format. You MUST:
     parts.append("")
 
     next_text = guidance.get("next", "")
-    if step >= WORKFLOW.total_steps or next_text.strip().upper() == "WORKFLOW COMPLETE.":
+    is_workflow_complete = step >= WORKFLOW.total_steps or next_text.strip().upper() == "WORKFLOW COMPLETE."
+    is_subagent_terminal = "SUB-AGENT TASK COMPLETE" in next_text.upper()
+
+    if is_workflow_complete:
         parts.append("WORKFLOW COMPLETE - Present report to user.")
+    elif is_subagent_terminal:
+        parts.append("SUB-AGENT TASK COMPLETE - Return results to parent agent.")
     else:
-        next_cmd = f'python3 -m skills.incoherence.incoherence --step-number {step + 1}'
+        next_cmd = f'python3 -m skills.incoherence.incoherence --step-number {step + 1} --thoughts \\"<ACCUMULATED_CONTEXT>\\"'
         parts.append(render_invoke_after(InvokeAfterNode(cmd=next_cmd)))
 
     return "\n".join(parts)
@@ -676,7 +685,7 @@ def main(
         phase = "APPLICATION"
 
     output = format_incoherence_output(
-        args.step_number, phase, agent_type, guidance
+        args.step_number, phase, agent_type, guidance, thoughts=args.thoughts
     )
     print(output)
 

--- a/skills/scripts/skills/incoherence/incoherence.py
+++ b/skills/scripts/skills/incoherence/incoherence.py
@@ -183,7 +183,7 @@ CRITICAL: All script outputs use XML format. You MUST:
     parts.append("")
 
     next_text = guidance.get("next", "")
-    if step >= total or "COMPLETE" in next_text.upper():
+    if step >= WORKFLOW.total_steps or next_text.strip().upper() == "WORKFLOW COMPLETE.":
         parts.append("WORKFLOW COMPLETE - Present report to user.")
     else:
         next_cmd = f'python3 -m skills.incoherence.incoherence --step-number {step + 1}'
@@ -647,6 +647,8 @@ def main(
     """
     parser = argparse.ArgumentParser(description="Incoherence Detector")
     parser.add_argument("--step-number", type=int, required=True)
+    parser.add_argument("--thoughts", type=str, default="",
+                        help="Accumulated context from previous steps")
     args = parser.parse_args()
 
     guidance = get_step_guidance(args.step_number, WORKFLOW.total_steps)


### PR DESCRIPTION
## Summary

- **Missing `--thoughts` CLI arg**: The skill docs and step guidance reference `--thoughts` for passing context between steps, but the argparse only defined `--step-number`. Added it as an optional string argument.
- **Undefined `total` variable**: `format_incoherence_output()` referenced bare `total` which was never defined, causing a `NameError`. Changed to `WORKFLOW.total_steps`.
- **False "WORKFLOW COMPLETE" trigger**: The check `"COMPLETE" in next_text.upper()` matched any step whose "next" text contained the word "complete" (e.g., step 3: "After all agents complete"). Changed to exact sentinel match `next_text.strip().upper() == "WORKFLOW COMPLETE."`.

## Test plan

- [x] Verified step 3 no longer false-triggers WORKFLOW COMPLETE (outputs `<invoke_after>` for step 4)
- [x] Verified step 21 correctly triggers WORKFLOW COMPLETE
- [x] Verified `--thoughts "test context"` is accepted without error
- [x] Ran full 21-step workflow end-to-end on a real repo